### PR TITLE
[TASK] Use Settings.yaml to subscribe to doctrine events

### DIFF
--- a/Classes/Ag/Event/Service/EventService.php
+++ b/Classes/Ag/Event/Service/EventService.php
@@ -11,20 +11,6 @@ require_once(FLOW_PATH_PACKAGES . '/Libraries/pda/pheanstalk/pheanstalk_init.php
 class EventService {
 
 	/**
-	 * @var \Doctrine\Common\Persistence\ObjectManager
-	 */
-	protected $entityManager;
-
-	/**
-	 * @param \Doctrine\Common\Persistence\ObjectManager $entityManager
-	 * @return void
-	 */
-	public function injectEntityManager(\Doctrine\Common\Persistence\ObjectManager $entityManager) {
-		$this->entityManager = $entityManager;
-		$this->entityManager->getEventManager()->addEventListener(array(\Doctrine\ORM\Events::postFlush), $this);
-	}
-
-	/**
 	 * @var array
 	 */
 	protected $settings;

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -3,3 +3,10 @@ TYPO3:
     object:
       excludeClasses:
         'pda.pheanstalk' : ['.*']
+
+    persistence:
+      doctrine:
+        eventListeners:
+          -
+            events: ['postFlush']
+            listener: 'Ag\Event\Service\EventService'

--- a/Configuration/Testing/Settings.yaml
+++ b/Configuration/Testing/Settings.yaml
@@ -3,3 +3,12 @@ Ag:
     eventHandlers:
       sync:
         'Ag\Event\EventHandler\StubEventHandler': 'Ag\Event\EventHandler\StubEventHandler'
+
+TYPO3:
+  Flow:
+    persistence:
+      doctrine:
+        eventListeners:
+          -
+            events: ['postFlush']
+            listener: 'Ag\Event\Service\EventService'

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "description": "",
     "version": "",
     "require": {
-		"typo3/flow": "2.0.*@beta",
-		"pda/pheanstalk": "2.1.*"
+        "typo3/flow": "dev-master",
+        "pda/pheanstalk": "2.1.*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
This works in production but the tests fail because <code>Ag\Event\Service\EventService::preFlush()</code> is called then.

I do think however, that that's maybe a bug elsewhere (aka Flow).
Note that this now requires Flow at dev-master.
