### PR TITLE
[TASK] Raise compatibility to current state

### DIFF
--- a/Classes/Ag/Event/Command/EventCommandController.php
+++ b/Classes/Ag/Event/Command/EventCommandController.php
@@ -1,46 +1,55 @@
 <?php
 namespace Ag\Event\Command;
 
+use Ag\Event\Domain\Model\DomainEvent;
+use Ag\Event\Service\EventService;
+use Pheanstalk\Pheanstalk;
 use TYPO3\Flow\Annotations as Flow;
-
-require_once(FLOW_PATH_PACKAGES . '/Libraries/pda/pheanstalk/pheanstalk_init.php');
-
+use TYPO3\Flow\Cli\CommandController;
+use TYPO3\Flow\Log\SystemLoggerInterface;
 
 /**
  * @Flow\Scope("singleton")
  */
-class EventCommandController extends \TYPO3\Flow\Cli\CommandController {
+class EventCommandController extends CommandController {
 
 	/**
-	 * @var \Ag\Event\Service\EventService
 	 * @Flow\Inject
+	 * @var EventService
 	 */
 	protected $eventService;
 
 	/**
-	 * @var \TYPO3\Flow\Log\SystemLoggerInterface
 	 * @Flow\Inject
+	 * @var SystemLoggerInterface
 	 */
 	protected $systemLogger;
+
+	/**
+	 * Note: this dependency injection is backed by Objects.yaml!
+	 *
+	 * @Flow\Inject
+	 * @var Pheanstalk
+	 */
+	protected $pheanstalk;
 
 	/**
 	 * @param string $key
 	 */
 	public function processCommand($key) {
-		$pheanstalk = new \Pheanstalk_Pheanstalk('127.0.0.1');
-
 		while(TRUE) {
 			$this->systemLogger->log('Waiting for event in tube ' . $key, LOG_DEBUG);
-			$job = $pheanstalk
+			$job = $this->pheanstalk
 				  ->watch($key)
 				  ->ignore('default')
 				  ->reserve();
 
-			$this->eventService->_syncPublish(unserialize($job->getData()), str_replace('_', '\\', $key));
+			/** @var $domainEvent DomainEvent */
+			$domainEvent = unserialize($job->getData());
+			$this->eventService->handleDomainEventByEventHandler($domainEvent, str_replace('_', '\\', $key));
 
-			$pheanstalk->delete($job);
+			$this->pheanstalk->delete($job);
 		}
 	}
-}
 
-?>
+}

--- a/Classes/Ag/Event/Domain/Model/DomainEvent.php
+++ b/Classes/Ag/Event/Domain/Model/DomainEvent.php
@@ -1,6 +1,8 @@
 <?php
 namespace Ag\Event\Domain\Model;
 
+/**
+ */
 abstract class DomainEvent {
 
 	/**
@@ -8,8 +10,10 @@ abstract class DomainEvent {
 	 */
 	public $occuredOn;
 
+	/**
+	 */
 	public function __construct() {
 		$this->occuredOn = new \DateTime();
 	}
+
 }
-?>

--- a/Classes/Ag/Event/Domain/Model/StoredEvent.php
+++ b/Classes/Ag/Event/Domain/Model/StoredEvent.php
@@ -29,9 +29,9 @@ class StoredEvent {
 	protected $event;
 
 	/**
-	 * @param \Ag\Event\Domain\Model\DomainEvent $event
+	 * @param DomainEvent $event
 	 */
-	public function __construct($event) {
+	public function __construct(DomainEvent $event) {
 		$this->occuredOn = clone $event->occuredOn;
 		$this->event = serialize($event);
 	}
@@ -44,10 +44,10 @@ class StoredEvent {
 	}
 
 	/**
-	 * @return \Ag\Event\Domain\Model\DomainEvent
+	 * @return DomainEvent
 	 */
 	public function getEvent() {
 		return unserialize($this->event);
 	}
+
 }
-?>

--- a/Classes/Ag/Event/EventHandler/EventHandler.php
+++ b/Classes/Ag/Event/EventHandler/EventHandler.php
@@ -1,13 +1,16 @@
 <?php
 namespace Ag\Event\EventHandler;
 
+use Ag\Event\Domain\Model\DomainEvent;
+
+/**
+ */
 interface EventHandler {
 
 	/**
-	 * @param \Ag\Event\Domain\Model\DomainEvent $event
+	 * @param DomainEvent $event
 	 * @return void
 	 */
-	public function handle(\Ag\Event\Domain\Model\DomainEvent $event);
+	public function handle(DomainEvent $event);
 
 }
-?>

--- a/Classes/Ag/Event/EventHandler/StubEventHandler.php
+++ b/Classes/Ag/Event/EventHandler/StubEventHandler.php
@@ -1,6 +1,7 @@
 <?php
 namespace Ag\Event\EventHandler;
 
+use Ag\Event\Domain\Model\DomainEvent;
 use TYPO3\Flow\Annotations as Flow;
 
 /**
@@ -14,12 +15,11 @@ class StubEventHandler implements EventHandler {
 	public $events = array();
 
 	/**
-	 * @param \Ag\Event\Domain\Model\DomainEvent $event
+	 * @param DomainEvent $event
 	 * @return void
 	 */
-	public function handle(\Ag\Event\Domain\Model\DomainEvent $event) {
+	public function handle(DomainEvent $event) {
 		$this->events[] = $event;
 	}
 
 }
-?>

--- a/Classes/Ag/Event/Exception/EventHandlingException.php
+++ b/Classes/Ag/Event/Exception/EventHandlingException.php
@@ -1,0 +1,11 @@
+<?php
+namespace Ag\Event\Exception;
+
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Exception as FlowBaseException;
+
+/**
+ */
+class EventHandlingException extends FlowBaseException {
+
+}

--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -1,0 +1,8 @@
+'Pheanstalk\Pheanstalk':
+  arguments:
+    1:
+      setting: 'Ag.Event.beanstalkd.host'
+    2:
+      setting: 'Ag.Event.beanstalkd.port'
+    3:
+      setting: 'Ag.Event.beanstalkd.timeout'

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,5 +1,23 @@
+Ag:
+  Event:
+    beanstalkd:
+      host: '127.0.0.1'
+      port: '%Pheanstalk\PheanstalkInterface::DEFAULT_PORT%'
+      timeout: NULL
+
+    eventHandlers:
+      sync: []
+      async: []
+
 TYPO3:
   Flow:
     object:
       excludeClasses:
         'pda.pheanstalk' : ['.*']
+
+    persistence:
+      doctrine:
+        eventListeners:
+          'Ag.Event':
+            events: ['postFlush']
+            listener: 'Ag\Event\Service\EventService'

--- a/Configuration/Testing/Settings.yaml
+++ b/Configuration/Testing/Settings.yaml
@@ -2,4 +2,4 @@ Ag:
   Event:
     eventHandlers:
       sync:
-        'Ag\Event\EventHandler\StubEventHandler': 'Ag\Event\EventHandler\StubEventHandler'
+        'Ag\Event\EventHandler\StubEventHandler': TRUE

--- a/Tests/Functional/EventService/StoreAndPublishTest.php
+++ b/Tests/Functional/EventService/StoreAndPublishTest.php
@@ -1,8 +1,15 @@
 <?php
 namespace Ag\Event\Tests\Functional\EventService;
 
-class StoreAndPublishTest extends \TYPO3\Flow\Tests\FunctionalTestCase {
+use TYPO3\Flow\Tests\FunctionalTestCase;
 
+/**
+ */
+class StoreAndPublishTest extends FunctionalTestCase {
+
+	/**
+	 * @var boolean
+	 */
 	static protected $testablePersistenceEnabled = TRUE;
 
 	/**
@@ -25,7 +32,8 @@ class StoreAndPublishTest extends \TYPO3\Flow\Tests\FunctionalTestCase {
 	 */
 	protected $stubEventHandler;
 
-
+	/**
+	 */
 	public function setUp() {
 		parent::setUp();
 
@@ -62,5 +70,5 @@ class StoreAndPublishTest extends \TYPO3\Flow\Tests\FunctionalTestCase {
 		$event = $this->storedEventRepository->findByIdentifier('2');
 		$this->assertEquals('Hello world #2', $event->getEvent()->getMessage());
 	}
+
 }
-?>

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "description": "",
     "version": "",
     "require": {
-		"typo3/flow": "2.1.*",
-		"pda/pheanstalk": "2.1.*"
+		"typo3/flow": "2.2.*",
+		"pda/pheanstalk": "3.0.*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
This raises the compatibility to Flow 2.2.\* and
Pheanstalk 3.0.*.

Besides, it does some code cleanup and uses DI and
Object Configuration for the Pheanstalk Library,
now since it's PSR-0 compatible.
