### PR TITLE
[!!!][TASK] Move actual event handling to sub process

### DIFF
--- a/Classes/Ag/Event/Command/EventCommandController.php
+++ b/Classes/Ag/Event/Command/EventCommandController.php
@@ -1,18 +1,18 @@
 <?php
 namespace Ag\Event\Command;
 
-use Ag\Event\Domain\Model\DomainEvent;
 use Ag\Event\Domain\Model\StoredEvent;
-use Ag\Event\Exception\EventHandlingException;
+use Ag\Event\Domain\Repository\StoredEventRepository;
+use Ag\Event\Exception\StoredEventNotFoundException;
 use Ag\Event\Service\EventService;
 use Pheanstalk\Job;
 use Pheanstalk\Pheanstalk;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Cli\CommandController;
+use TYPO3\Flow\Core\Booting\Scripts;
 use TYPO3\Flow\Log\SystemLoggerInterface;
 
 /**
- * @Flow\Scope("singleton")
  */
 class EventCommandController extends CommandController {
 
@@ -27,10 +27,23 @@ class EventCommandController extends CommandController {
 	const QUEUE_TIMEOUT = 20;
 
 	/**
+	 * Populated via Objects.yaml.
+	 *
+	 * @var array
+	 */
+	protected $subProcessCommandSettings;
+
+	/**
 	 * @Flow\Inject
 	 * @var EventService
 	 */
 	protected $eventService;
+
+	/**
+	 * @Flow\Inject
+	 * @var StoredEventRepository
+	 */
+	protected $storedEventRepository;
 
 	/**
 	 * @Flow\Inject
@@ -65,10 +78,15 @@ class EventCommandController extends CommandController {
 
 				/** @var $storedEvent StoredEvent */
 				$storedEvent = unserialize($job->getData());
-
-				$this->tellStatus('Attempt to handle event #%s.', array($storedEvent->getEventId()));
-
-				$this->eventService->handleDomainEventByEventHandler($storedEvent->getEvent(), str_replace('_', '\\', $key));
+				Scripts::executeCommand(
+					'ag.event:event:handle',
+					$this->subProcessCommandSettings,
+					TRUE,
+					array(
+						'eventId' => $storedEvent->getEventId(),
+						'eventHandler' => $key
+					)
+				);
 
 				$this->pheanstalk->delete($job);
 				$this->tellStatus('Deleted job #%d in tube "%s".', array($job->getId(), $key));
@@ -80,6 +98,22 @@ class EventCommandController extends CommandController {
 		}
 
 		$this->tellStatus('Event processor exited intentionally.');
+	}
+
+	/**
+	 * @param string $eventId The Event ID to handle
+	 * @param string $eventHandler The event handler as identifier, e.g. Acme_Notification_Domain_EventHandler_ProductBackInStock
+	 * @throws StoredEventNotFoundException
+	 */
+	public function handleCommand($eventId, $eventHandler ) {
+		$storedEvent = $this->storedEventRepository->findByIdentifier($eventId);
+		if ($storedEvent === NULL) {
+			throw new StoredEventNotFoundException(sprintf('The Domain Event with ID "%s" was not found.', $eventId), 1422956394);
+		}
+
+		$this->tellStatus('Attempt to handle event #%s with handler "%s".', array($storedEvent->getEventId(), $eventHandler));
+		$this->eventService->handleDomainEventByEventHandler($storedEvent->getEvent(), str_replace('_', '\\', $eventHandler));
+
 	}
 
 	/**

--- a/Classes/Ag/Event/Exception/StoredEventNotFoundException.php
+++ b/Classes/Ag/Event/Exception/StoredEventNotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+namespace Ag\Event\Exception;
+
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Exception as FlowBaseException;
+
+/**
+ */
+class StoredEventNotFoundException extends FlowBaseException {
+
+}

--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -1,3 +1,10 @@
+'Ag\Event\Command\EventCommandController':
+  properties:
+    'subProcessCommandSettings':
+      # according to the doc comment of \TYPO3\Flow\Core\Booting\Scripts::executeCommand,
+      # the settings which are passed there must be the (complete) TYPO3.FLow settings.
+      setting: 'TYPO3.Flow'
+
 'Pheanstalk\Pheanstalk':
   arguments:
     1:


### PR DESCRIPTION
This introduces a new command ``ag.event:event.handle``
which will actually handle a given event with a given
event handler. The initial queue process will internally
call this command as a sub process.

This is necessary in order to avoid the problems the
long running PHP process will lead to, like, for example,
Singletons staying the same all the time, the Entity Manager
with its Identity Map not fetching the current peristence
state; etc.

This is marked breaking in cases where the sub process
invocation might need some additional configuration to work
on the system it's running on.

Resolves #11